### PR TITLE
Added TriggerMonitoring plots to WebServer

### DIFF
--- a/cgi-bin/monitoring.cgi
+++ b/cgi-bin/monitoring.cgi
@@ -39,6 +39,7 @@ Monitoring</span>
       <a class=\"mdl-layout__tab\" href=\"./Checklist.html\" onclick=\"window.open('./Checklist.html','_self');\">Checklist</a>
       <a class=\"mdl-layout__tab\" href=\"./MRDSummary.html\" onclick=\"window.open('./MRDSummary.html','_self');\">MRD Summary</a>
       <a class=\"mdl-layout__tab\" href=\"./TankSummary.html\" onclick=\"window.open('./TankSummary.html','_self');\">Tank Summary</a>
+      <a class=\"mdl-layout__tab\" href=\"./TriggerSummary.html\" onclick=\"window.open('./TriggerSummary.html','_self');\">Trigger Summary</a>
       <a class=\"mdl-layout__tab\" href=\"./MRDLastFile.html\" onclick=\"window.open('./MRDLastFile.html','_self');\">MRD LastFile</a>
       <a class=\"mdl-layout__tab\" href=\"./MRDHitmaps.html\" onclick=\"window.open('./MRDHitmaps.html','_self');\">MRD Hitmaps</a>
       <a class=\"mdl-layout__tab\" href=\"./MRDTimeEvolution.html\" onclick=\"window.open('./MRDTimeEvolution.html','_self');\">MRD TimeEvolution</a>
@@ -47,6 +48,8 @@ Monitoring</span>
       <a class=\"mdl-layout__tab\" href=\"./TankTimeEvolution.html\" onclick=\"window.open('./TankTimeEvolution.html','_self');\">Tank TimeEvolution</a>
       <a class=\"mdl-layout__tab\" href=\"./TankFrequency.html\" onclick=\"window.open('./TankFrequency.html','_self');\">Tank Frequency</a>
       <a class=\"mdl-layout__tab\" href=\"./TankBuffer.html\" onclick=\"window.open('./TankBuffer.html','_self');\">Tank Buffer</a>
+      <a class=\"mdl-layout__tab\" href=\"./TriggerRates.html\" onclick=\"window.open('./TriggerRates.html','_self');\">Trigger Rates</a>
+      <a class=\"mdl-layout__tab\" href=\"./TriggerAlignment.html\" onclick=\"window.open('./TriggerAlignment.html','_self');\">Trigger Alignment</a>
     </div> 
 
   </header>

--- a/html/Checklist.html
+++ b/html/Checklist.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab is-active" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+       <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>
@@ -82,7 +87,7 @@ Monitoring</span>
 <p> </p>
 <div style="width:3%; overflow: hidden; float: left;"> &ensp;</div>
 <div style="width:20%; overflow: hidden; float: left;"> <b>3)</b> Are all 3 features (background/beam/cosmic) visible in MRD data? </div>
-<img src="./monitoringplots/MRDTDCHist_Cluster_lastFile.png"  width="35%" height="40%">
+<img src="./monitoringplots/MRDTDCHist_Cluster_last20Files.png"  width="35%" height="40%">
 <img src="./monitoringplots/MRDTDCHist_Cluster_lastFile_Reference.png"  width="35%" height="40%">
 <p> </p>
 <div style="width:3%; overflow: hidden; float: left;"> &ensp;</div>
@@ -106,17 +111,27 @@ Monitoring</span>
 <img src="./monitoringplots/PMT_Ped_Electronics_lastFile_Reference.jpg"  width="35%" height="40%">
 <p> </p>
 <div style="width:3%; overflow: hidden; float: left;"> &ensp;</div>
-<div style="width:20%; overflow: hidden; float: left;"> <b>8)</b> Do all active PMTs have a rate larger than 0?</div>
+<div style="width:20%; overflow: hidden; float: left;"> <b>8a)</b> Do all active PMTs have a rate larger than 0?</div>
 <img src="./monitoringplots/PMT_Rate_Electronics_lastFile.jpg"  width="35%" height="40%">
 <img src="./monitoringplots/PMT_Rate_Electronics_lastFile_Reference.jpg"  width="35%" height="40%">
 <p> </p>
 <div style="width:3%; overflow: hidden; float: left;"> &ensp;</div>
-<div style="width:20%; overflow: hidden; float: left;"> <b>9)</b> Does the BRF buffer look like the reference?</div>
+<div style="width:20%; overflow: hidden; float: left;"> <b>8b)</b> Do all active PMTs have a rate larger than 0? (alternative view) </div>
+<img src="./monitoringplots/PMTHitmap_lastFile.png"  width="35%" height="40%">
+<img src="./monitoringplots/PMTHitmap_lastFile_Reference.png"  width="35%" height="40%">
+<p> </p>
+<div style="width:3%; overflow: hidden; float: left;"> &ensp;</div>
+<div style="width:20%; overflow: hidden; float: left;"> <b>9)</b> Are the trigger rates roughly in the right order of magnitude?</div>
+<img src="./monitoringplots/Trigger_Rate_selected_lastFile.png"  width="35%" height="40%">
+<img src="./monitoringplots/Trigger_Rate_selected_lastFile_Reference.png"  width="35%" height="40%">
+<p> </p>
+<div style="width:3%; overflow: hidden; float: left;"> &ensp;</div>
+<div style="width:20%; overflow: hidden; float: left;"> <b>10)</b> Does the BRF buffer look like the reference?</div>
 <img src="./monitoringplots/PMT_Temp_BRF.jpg"  width="35%" height="40%">
 <img src="./monitoringplots/PMT_Temp_BRF_Reference.jpg"  width="35%" height="40%">
 <p> </p>
 <div style="width:3%; overflow: hidden; float: left;"> &ensp;</div>
-<div style="width:20%; overflow: hidden; float: left;"> <b>10)</b> Does the RWM buffer look like the reference?</div>
+<div style="width:20%; overflow: hidden; float: left;"> <b>11)</b> Does the RWM buffer look like the reference?</div>
 <img src="./monitoringplots/PMT_Temp_RWM.jpg"  width="35%" height="40%">
 <img src="./monitoringplots/PMT_Temp_RWM_Reference.jpg"  width="35%" height="40%">
 

--- a/html/MRDHitmaps.html
+++ b/html/MRDHitmaps.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab is-active" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>

--- a/html/MRDLastFile.html
+++ b/html/MRDLastFile.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab is-active" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+       <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
 

--- a/html/MRDRates.html
+++ b/html/MRDRates.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>

--- a/html/MRDTimeEvolution.html
+++ b/html/MRDTimeEvolution.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab is-active" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>

--- a/html/TankBuffer.html
+++ b/html/TankBuffer.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab is-active" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>

--- a/html/TankElectronics.html
+++ b/html/TankElectronics.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
     <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+       <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
   </header>
   <div class="mdl-layout__drawer">
@@ -89,6 +94,74 @@ Monitoring</span>
 <p> </p>
 <img src="./monitoringplots/PMT_FIFO1_Electronics_lastFile.jpg"  width="45%" height="40%">
 <img src="./monitoringplots/PMT_FIFO2_Electronics_lastFile.jpg"  width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl4_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl5_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl6_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl7_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl10_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl11_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl12_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl13_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl14_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl3_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl4_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl5_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl6_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl9_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl10_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl11_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl13_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl14_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl15_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl18_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl3_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl4_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl5_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl6_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl9_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl10_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl11_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl12_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl13_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl14_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl15_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl18_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl19_lastFile.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl4_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl5_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl6_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl7_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl10_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl11_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl12_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl13_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr1_Sl14_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl3_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl4_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl5_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl6_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl9_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl10_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl11_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl13_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl14_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl15_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr2_Sl18_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl3_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl4_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl5_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl6_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl9_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl10_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl11_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl12_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl13_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl14_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl15_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl18_lastDay.png"   width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_Cr3_Sl19_lastDay.png"   width="45%" height="40%">
 
 
 </div>

--- a/html/TankFrequency.html
+++ b/html/TankFrequency.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab is-active" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
     </div> 
 
   </header>

--- a/html/TankSummary.html
+++ b/html/TankSummary.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab is-active" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+       <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>
@@ -86,6 +91,12 @@ Monitoring</span>
 <p>  </p>
 <img src="./monitoringplots/PMT_Temp_RWM.jpg"  width="45%" height="40%">
 <img src="./monitoringplots/PMT_Temp_BRF.jpg"  width="45%" height="40%">
+<p> </p>
+<img src="./monitoringplots/PMTHitmap_lastFile.png"  width="45%" height="40%">
+<img src="./monitoringplots/PMTHitmap_lastDay.png"  width="45%" height="40%">
+<p>  </p>
+<img src="./monitoringplots/VMEHist_Cluster_last20Files.png"  width="45%" height="40%">
+<img src="./monitoringplots/VMEHist_lastFile.png"  width="45%" height="40%">
 
 
 </div>

--- a/html/TankTimeEvolution.html
+++ b/html/TankTimeEvolution.html
@@ -7,7 +7,9 @@
 <script defer src="https://code.getmdl.io/1.1.2/material.min.js"></script>
  <link rel="stylesheet" href="https://code.getmdl.io/1.1.2/material.indigo-deep_purple.min.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+<meta http-equiv="Pragma" content="no-cache"/>
+<meta http-equiv="Expires" content="0"/>
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
@@ -36,6 +38,7 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
       <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
+      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -44,6 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab is-active" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
+      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>

--- a/html/TriggerAlignment.html
+++ b/html/TriggerAlignment.html
@@ -33,22 +33,22 @@ Monitoring</span>
       </nav>
     </div>
 
-          <div class="mdl-layout__tab-bar mdl-js-ripple-effect">
+    <div class="mdl-layout__tab-bar mdl-js-ripple-effect">
       <a href="/cgi-bin/monitoring.cgi" class="mdl-layout__tab" onclick="window.open('/cgi-bin/monitoring.cgi','_self');">All Plots</a>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
-      <a class="mdl-layout__tab is-active" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
+      <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
       <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
-      <a class="mdl-layout__tab" href="./MRDRates.html" onclick="window.open('./MRDRates.html','_self');">MRD Rates</a>
+      <a class="mdl-layout__tab is-active" href="./MRDRates.html" onclick="window.open('./MRDRates.html','_self');">MRD Rates</a>
       <a class="mdl-layout__tab" href="./TankElectronics.html" onclick="window.open('./TankElectronics.html','_self');">Tank Electronics</a>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
       <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
-      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
+      <a class="mdl-layout__tab is-active" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>
@@ -74,23 +74,39 @@ Monitoring</span>
 
 <p>  </p>
 
-<img src="./monitoringplots/MRD_FileHistory_current_24h.png"  width="35%" height="40%">
-<img src="./monitoringplots/MRD_FileHistory_current_2h.png"  width="35%" height="40%">
-<img src="./monitoringplots/MRD_FileTimeStamp_current_24h.png"  width="20%" height="20%">
-<p>  </p>
-<img src="./monitoringplots/MRDTriggertypes_timeevolution_lastDay.png"  width="45%" height="40%">
-<img src="./monitoringplots/MRDHitmap_lastDay.png"  width="45%" height="40%"> 
-<p>  </p>
-<img src="./monitoringplots/MRDTDCHist_Cluster_lastFile.png"  width="45%" height="40%">
-<img src="./monitoringplots/MRDHitmap_lastFile.png"  width="45%" height="40%">
-<p>  </p>
-<img src="./monitoringplots/MRDRates_Detector_lastFile.png"  width="45%" height="
+<img src="./monitoringplots/Trigger_Align_1_0.png"  width="45%" height="
 40%">
-<img src="./monitoringplots/MRDRates_DetectorFACC_lastFile.png"  width="45%" height="40%">   
+<img src="./monitoringplots/Trigger_Align_3_36.png"  width="45%" height="
+40%">
 <p>  </p>
-<div style="width:25%; overflow: hidden; float: left;"> &ensp;</div>
-<img src="./monitoringplots/MRDRates_Electronics_lastFile.png"  width="45%" height="40%">    
-                                                     
+<img src="./monitoringplots/Trigger_Align_4_3.png"  width="45%" height="40%">  
+<img src="./monitoringplots/Trigger_Align_5_4.png"  width="45%" height="40%">  
+<p>  </p>
+<img src="./monitoringplots/Trigger_Align_6_37.png"  width="45%" height="40%">   
+<img src="./monitoringplots/Trigger_Align_7_6.png"  width="45%" height="40%">
+<p>  </p>
+<img src="./monitoringplots/Trigger_Align_21_32.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Align_32_45.png"  width="45%" height="40%">
+<p>  </p>
+<img src="./monitoringplots/Trigger_Align_33_31.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Align_37_45.png"  width="45%" height="40%">
+<p>  </p>
+<img src="./monitoringplots/Trigger_Align_45_5.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Align_45_21.png"  width="45%" height="40%">
+<p>  </p>
+<img src="./monitoringplots/Trigger_Align_45_34.png"  width="45%" height="40%">
+<p>  </p>
+<img src="./monitoringplots/Trigger_Timestamps_bes_holdoff.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_Delay_beam_trigger1.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_input_1d.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_input_1f.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_input_8f.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_input_sync.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_LED_adc_trigger.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_MinRate_trigger.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_MRD_CR_trigger.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_Periodic_trigger.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Timestamps_Selftrigger_ADC.png"  width="45%" height="40%">
 
 
 </div>

--- a/html/TriggerRates.html
+++ b/html/TriggerRates.html
@@ -33,10 +33,10 @@ Monitoring</span>
       </nav>
     </div>
 
-          <div class="mdl-layout__tab-bar mdl-js-ripple-effect">
+    <div class="mdl-layout__tab-bar mdl-js-ripple-effect">
       <a href="/cgi-bin/monitoring.cgi" class="mdl-layout__tab" onclick="window.open('/cgi-bin/monitoring.cgi','_self');">All Plots</a>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
-      <a class="mdl-layout__tab is-active" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
+      <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
       <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
@@ -47,8 +47,8 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
-      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
-      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
+      <a class="mdl-layout__tab is-active" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
+       <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>
@@ -74,23 +74,34 @@ Monitoring</span>
 
 <p>  </p>
 
-<img src="./monitoringplots/MRD_FileHistory_current_24h.png"  width="35%" height="40%">
-<img src="./monitoringplots/MRD_FileHistory_current_2h.png"  width="35%" height="40%">
-<img src="./monitoringplots/MRD_FileTimeStamp_current_24h.png"  width="20%" height="20%">
+<img src="./monitoringplots/Trigger_Rate_lastFile.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Rate_lastDay.png"  width="45%" height="40%">
 <p>  </p>
-<img src="./monitoringplots/MRDTriggertypes_timeevolution_lastDay.png"  width="45%" height="40%">
-<img src="./monitoringplots/MRDHitmap_lastDay.png"  width="45%" height="40%"> 
+<img src="./monitoringplots/Trigger_Rate_selected_lastFile.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Rate_selected_lastDay.png"  width="45%" height="40%">
 <p>  </p>
-<img src="./monitoringplots/MRDTDCHist_Cluster_lastFile.png"  width="45%" height="40%">
-<img src="./monitoringplots/MRDHitmap_lastFile.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Freq_lastFile.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Freq_lastDay.png"  width="45%" height="40%">
 <p>  </p>
-<img src="./monitoringplots/MRDRates_Detector_lastFile.png"  width="45%" height="
-40%">
-<img src="./monitoringplots/MRDRates_DetectorFACC_lastFile.png"  width="45%" height="40%">   
+<img src="./monitoringplots/Trigger_Freq_selected_lastFile.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Freq_selected_lastDay.png"  width="45%" height="40%">
 <p>  </p>
-<div style="width:25%; overflow: hidden; float: left;"> &ensp;</div>
-<img src="./monitoringplots/MRDRates_Electronics_lastFile.png"  width="45%" height="40%">    
-                                                     
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword4_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword8_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword12_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword16_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword20_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword24_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword28_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword32_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword36_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword40_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword44_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword48_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword52_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword56_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword60_lastDay.png"  width="45%" height="40%">
+<img src="./monitoringplots/TrigTimeEvolution_Rate_Trigword63_lastDay.png"  width="45%" height="40%">
 
 
 </div>

--- a/html/TriggerSummary.html
+++ b/html/TriggerSummary.html
@@ -13,6 +13,8 @@
   <link rel="stylesheet" href="styles.css"> 
 <body>
 
+
+
 <!-- Always shows a header, even in smaller screens. -->
 <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
   <header class="mdl-layout__header">
@@ -33,12 +35,12 @@ Monitoring</span>
       </nav>
     </div>
 
-          <div class="mdl-layout__tab-bar mdl-js-ripple-effect">
+      <div class="mdl-layout__tab-bar mdl-js-ripple-effect">
       <a href="/cgi-bin/monitoring.cgi" class="mdl-layout__tab" onclick="window.open('/cgi-bin/monitoring.cgi','_self');">All Plots</a>
       <a class="mdl-layout__tab" href="./Checklist.html" onclick="window.open('./Checklist.html','_self');">Checklist</a>
-      <a class="mdl-layout__tab is-active" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
+      <a class="mdl-layout__tab" href="./MRDSummary.html" onclick="window.open('./MRDSummary.html','_self');">MRD Summary</a>
       <a class="mdl-layout__tab" href="./TankSummary.html" onclick="window.open('./TankSummary.html','_self');">Tank Summary</a>
-      <a class="mdl-layout__tab" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
+      <a class="mdl-layout__tab is-active" href="./TriggerSummary.html" onclick="window.open('./TriggerSummary.html','_self');">Trigger Summary</a>
       <a class="mdl-layout__tab" href="./MRDLastFile.html" onclick="window.open('./MRDLastFile.html','_self');">MRD LastFile</a>
       <a class="mdl-layout__tab" href="./MRDHitmaps.html" onclick="window.open('./MRDHitmaps.html','_self');">MRD Hitmaps</a>
       <a class="mdl-layout__tab" href="./MRDTimeEvolution.html" onclick="window.open('./MRDTimeEvolution.html','_self');">MRD TimeEvolution</a>
@@ -47,8 +49,6 @@ Monitoring</span>
       <a class="mdl-layout__tab" href="./TankTimeEvolution.html" onclick="window.open('./TankTimeEvolution.html','_self');">Tank TimeEvolution</a>
       <a class="mdl-layout__tab" href="./TankFrequency.html" onclick="window.open('./TankFrequency.html','_self');">Tank Frequency</a>
       <a class="mdl-layout__tab" href="./TankBuffer.html" onclick="window.open('./TankBuffer.html','_self');">Tank Buffer</a>
-      <a class="mdl-layout__tab" href="./TriggerRates.html" onclick="window.open('./TriggerRates.html','_self');">Trigger Rates</a>
-      <a class="mdl-layout__tab" href="./TriggerAlignment.html" onclick="window.open('./TriggerAlignment.html','_self');">Trigger Alignment</a>
   </div>
 
   </header>
@@ -68,29 +68,23 @@ Monitoring</span>
   <main class="mdl-layout__content">
     <div class="page-content">
 
+
 <!-- Your content goes here -->
 <!-- <p> <a href="/cgi-bin/monitoring.cgi">All Plots</a> , <a href="./MRDSummary.html">MRD Summary</a> , <a href="./MRDLastFile.html"> MRD LastFile</a> , <a href="./MRDHitmaps.html"> MRD Hitmaps</a> , <a href="./MRDTimeEvolution.html"> MRD TimeEvolution</a> , <a href="./MRDRates.html"> MRD Rates</a> , <a href="./TankSummary.html"> Tank Summary</a> , <a href="./TankElectronics.html"> Tank Electronics</a> , <a href="./TankTimeEvolution.html"> Tank TimeEvolution</a> , <a href="./TankFrequency.html"> Tank Frequency</a> , <a href="./TankBuffer.html"> Tank Buffer</a>
-</p>-->
+</p> -->
 
 <p>  </p>
 
-<img src="./monitoringplots/MRD_FileHistory_current_24h.png"  width="35%" height="40%">
-<img src="./monitoringplots/MRD_FileHistory_current_2h.png"  width="35%" height="40%">
-<img src="./monitoringplots/MRD_FileTimeStamp_current_24h.png"  width="20%" height="20%">
+
+<img src="./monitoringplots/Trigger_FileHistory_current_24h.png"  width="35%" height="40%">
+<img src="./monitoringplots/Trigger_FileHistory_current_2h.png"  width="35%" height="40%">
+<img src="./monitoringplots/Trigger_FileTimeStamp_current_24h.png"  width="20%" height="20%">
 <p>  </p>
-<img src="./monitoringplots/MRDTriggertypes_timeevolution_lastDay.png"  width="45%" height="40%">
-<img src="./monitoringplots/MRDHitmap_lastDay.png"  width="45%" height="40%"> 
+<img src="./monitoringplots/Trigger_Rate_lastFile.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Rate_lastDay.png"  width="45%" height="40%">
 <p>  </p>
-<img src="./monitoringplots/MRDTDCHist_Cluster_lastFile.png"  width="45%" height="40%">
-<img src="./monitoringplots/MRDHitmap_lastFile.png"  width="45%" height="40%">
-<p>  </p>
-<img src="./monitoringplots/MRDRates_Detector_lastFile.png"  width="45%" height="
-40%">
-<img src="./monitoringplots/MRDRates_DetectorFACC_lastFile.png"  width="45%" height="40%">   
-<p>  </p>
-<div style="width:25%; overflow: hidden; float: left;"> &ensp;</div>
-<img src="./monitoringplots/MRDRates_Electronics_lastFile.png"  width="45%" height="40%">    
-                                                     
+<img src="./monitoringplots/Trigger_Rate_selected_lastFile.png"  width="45%" height="40%">
+<img src="./monitoringplots/Trigger_Rate_selected_lastDay.png"  width="45%" height="40%">
 
 
 </div>


### PR DESCRIPTION
Additional html pages were added to the repository in order to display trigger-related monitoring plots. (`TriggerSummary.html`, `TriggerRates.html`, `TriggerAlignment.html`). 
Tank PMT hitmap plots were added to the `TankElectronics.html` page alongside other minor plot changes.
Some meta information was added to the html pages to try prevent too much caching of the plots.